### PR TITLE
Added testing #3

### DIFF
--- a/src/AbeckDev.Amadeus.Test/AbeckDev.Amadeus.Test.csproj
+++ b/src/AbeckDev.Amadeus.Test/AbeckDev.Amadeus.Test.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/src/AbeckDev.Amadeus.Test/AmadeusClientTests.cs
+++ b/src/AbeckDev.Amadeus.Test/AmadeusClientTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AbeckDev.Amadeus.Configuration;
+using AbeckDev.Amadeus.Exceptions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AbeckDev.Amadeus.Test
+{
+
+    public class AmadeusClientTests : IDisposable
+    {
+        private readonly Mock<HttpMessageHandler> _mockHandler;
+        private readonly AmadeusClientOptions _defaultOptions;
+
+        public AmadeusClientTests()
+        {
+            _mockHandler = new Mock<HttpMessageHandler>();
+            _defaultOptions = new AmadeusClientOptions(new Uri("https://api.amadeus.com/"))
+            {
+                TransportHandler = _mockHandler.Object
+            };
+        }
+
+        [Fact]
+        public void Constructor_WithValidOptions_ShouldCreateInstance()
+        {
+            // Arrange & Act
+            using var client = new AmadeusClient(_defaultOptions);
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void Constructor_WithNullOptions_ShouldThrowArgumentNullException()
+        {
+            // Arrange, Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new AmadeusClient(null!));
+        }
+
+        [Fact]
+        public void Constructor_WithLogger_ShouldCreateInstance()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger>();
+
+            // Act
+            using var client = new AmadeusClient(_defaultOptions, mockLogger.Object);
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void Dispose_WithDefaultTransport_ShouldDisposeTransport()
+        {
+            // Arrange
+            var options = new AmadeusClientOptions(new Uri("https://api.amadeus.com/"))
+            {
+                // No custom transport handler - should create and dispose its own
+            };
+
+            // Act & Assert - Should not throw
+            using var client = new AmadeusClient(options);
+            client.Dispose();
+        }
+
+        public void Dispose()
+        {
+            _mockHandler?.Object?.Dispose();
+        }
+    }
+}

--- a/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
+++ b/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
@@ -132,10 +132,20 @@ public class ClientOptionTests
         // Arrange
         var options = new AmadeusClientOptions(_testEndpoint);
         var policy1 = new TestPipelinePolicy();
-        var policy2 = new AuthPolicy(new BearerTokenProvider(new HttpClient(),"","",""),null!);
+        using (var httpClient = new HttpClient())
+        {
+            var policy2 = new AuthPolicy(
+                new BearerTokenProvider(httpClient, "testClientId", "testClientSecret", "testTokenEndpoint"),
+                null!);
 
-        // Act
-        options.AddPolicy(policy1).AddPolicy(policy2);
+            // Act
+            options.AddPolicy(policy1).AddPolicy(policy2);
+
+            // Assert
+            Assert.Equal(2, options.AdditionalPolicies.Count);
+            Assert.Contains(policy1, options.AdditionalPolicies);
+            Assert.Contains(policy2, options.AdditionalPolicies);
+        }
 
         // Assert
         Assert.Equal(2, options.AdditionalPolicies.Count);

--- a/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
+++ b/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
@@ -93,7 +93,7 @@ public class ClientOptionTests
     {
         public async Task<HttpResponseMessage> ProcessAsync(PipelineContext context, HttpRequestMessage request, PipelineCall next, CancellationToken cancellationToken)
         {
-            //Do nothing and just return the plain object again
+            // Pass through to next policy without modification
             var response = await next(context, request, cancellationToken).ConfigureAwait(false);
             return response;
 

--- a/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
+++ b/src/AbeckDev.Amadeus.Test/ClientOptionTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using AbeckDev.Amadeus.Abstractions;
+using AbeckDev.Amadeus.Pipeline;
+using AbeckDev.Amadeus.Configuration;
+using AbeckDev.Amadeus.Pipeline.Policies;
+using Xunit;
+using AbeckDev.Amadeus.Auth;
+
+namespace AbeckDev.Amadeus.Test;
+
+public class ClientOptionTests
+{
+    private readonly Uri _testEndpoint = new Uri("https://test.api.amadeus.com");
+
+    [Fact]
+    public void Constructor_WithValidEndpoint_SetsEndpointProperty()
+    {
+        // Arrange & Act
+        var options = new AmadeusClientOptions(_testEndpoint);
+
+        // Assert
+        Assert.Equal(_testEndpoint, options.Endpoint);
+    }
+
+    [Fact]
+    public void Constructor_WithNullEndpoint_ThrowsArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AmadeusClientOptions(null!));
+    }
+
+    [Fact]
+    public void DefaultProperties_HaveExpectedValues()
+    {
+        // Arrange & Act
+        var options = new AmadeusClientOptions(_testEndpoint);
+
+        // Assert
+        Assert.Null(options.TokenProvider);
+        Assert.Empty(options.DefaultScopes);
+        Assert.NotNull(options.Retry);
+        Assert.Equal(TimeSpan.FromSeconds(100), options.DefaultTimeout);
+        Assert.True(options.EnableTelemetry);
+        Assert.Null(options.TransportHandler);
+        Assert.Empty(options.AdditionalPolicies);
+    }
+
+
+    //Mock Token Provider
+    class TestTokenProvider : ITokenProvider
+    {
+        public ValueTask<AccessToken> GetTokenAsync(TokenRequestContext context, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [Fact]
+    public void CustomProperties_SetCorrectly()
+    {
+
+        // Define test data
+        var tokenProvider = new TestTokenProvider();
+        var scopes = new[] { "scope1", "scope2" };
+        var retry = new RetryOptions { MaxAttempts = 10 };
+        var timeout = TimeSpan.FromSeconds(200);
+        var telemetry = false;
+        var handler = new HttpClientHandler();
+
+        // Create Options object
+        var options = new AmadeusClientOptions(_testEndpoint)
+        {
+            TokenProvider = tokenProvider,
+            DefaultScopes = scopes,
+            Retry = retry,
+            DefaultTimeout = timeout,
+            EnableTelemetry = telemetry,
+            TransportHandler = handler
+        };
+
+        // Check
+        Assert.Same(tokenProvider, options.TokenProvider);
+        Assert.Same(scopes, options.DefaultScopes);
+        Assert.Same(retry, options.Retry);
+        Assert.Equal(timeout, options.DefaultTimeout);
+        Assert.Equal(telemetry, options.EnableTelemetry);
+        Assert.Same(handler, options.TransportHandler);
+    }
+
+    class TestPipelinePolicy : IHttpPipelinePolicy
+    {
+        public async Task<HttpResponseMessage> ProcessAsync(PipelineContext context, HttpRequestMessage request, PipelineCall next, CancellationToken cancellationToken)
+        {
+            //Do nothing and just return the plain object again
+            var response = await next(context, request, cancellationToken).ConfigureAwait(false);
+            return response;
+
+        }
+    }
+
+    [Fact]
+    public void AddPolicy_WithValidPolicy_AddsPolicyToCollection()
+    {
+        // Arrange
+        var options = new AmadeusClientOptions(_testEndpoint);
+        var policy = new TestPipelinePolicy();
+
+        // Act
+        var result = options.AddPolicy(policy);
+
+        // Assert
+        Assert.Same(options, result); // Fluent return
+        Assert.Single(options.AdditionalPolicies);
+        Assert.Same(policy, options.AdditionalPolicies.First());
+    }
+
+    [Fact]
+    public void AddPolicy_WithNullPolicy_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var options = new AmadeusClientOptions(_testEndpoint);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => options.AddPolicy(null!));
+    }
+
+    [Fact]
+    public void AddPolicy_MultiplePolicies_AddsAllPolicies()
+    {
+        // Arrange
+        var options = new AmadeusClientOptions(_testEndpoint);
+        var policy1 = new TestPipelinePolicy();
+        var policy2 = new AuthPolicy(new BearerTokenProvider(new HttpClient(),"","",""),null!);
+
+        // Act
+        options.AddPolicy(policy1).AddPolicy(policy2);
+
+        // Assert
+        Assert.Equal(2, options.AdditionalPolicies.Count);
+        Assert.Contains(policy1, options.AdditionalPolicies);
+        Assert.Contains(policy2, options.AdditionalPolicies);
+    }
+
+    [Fact]
+    public void RetryOptions_DefaultValues()
+    {
+        // Arrange & Act
+        var retryOptions = new RetryOptions();
+
+        // Assert
+        Assert.Equal(5, retryOptions.MaxAttempts);
+        Assert.Equal(TimeSpan.FromMilliseconds(200), retryOptions.BaseDelay);
+        Assert.Equal(TimeSpan.FromSeconds(5), retryOptions.MaxDelay);
+        Assert.True(retryOptions.RetryOnTimeouts);
+    }
+
+    [Fact]
+    public void RetryOptions_CustomValues()
+    {
+        // Arrange & Act
+        var retryOptions = new RetryOptions
+        {
+            MaxAttempts = 10,
+            BaseDelay = TimeSpan.FromMilliseconds(500),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            RetryOnTimeouts = false
+        };
+
+        // Assert
+        Assert.Equal(10, retryOptions.MaxAttempts);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), retryOptions.BaseDelay);
+        Assert.Equal(TimeSpan.FromSeconds(30), retryOptions.MaxDelay);
+        Assert.False(retryOptions.RetryOnTimeouts);
+    }
+
+    
+}

--- a/src/AbeckDev.Amadeus.Test/ExceptionTests.cs
+++ b/src/AbeckDev.Amadeus.Test/ExceptionTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using AbeckDev.Amadeus.Exceptions;
+using Xunit;
+
+namespace AbeckDev.Amadeus.Test
+{
+    public class AmadeusRequestExceptionTests
+    {
+        [Fact]
+        public void Constructor_InitializesProperties()
+        {
+            // Arrange
+            const string message = "Test error message";
+            const HttpStatusCode statusCode = HttpStatusCode.BadRequest;
+            const string responseBody = "Error details from API";
+            const string correlationId = "abc-123-xyz";
+            var innerException = new InvalidOperationException("Inner exception");
+
+            // Act
+            var exception = new AmadeusRequestException(
+                message,
+                statusCode,
+                responseBody,
+                correlationId,
+                innerException);
+
+            // Assert
+            Assert.Equal(message, exception.Message);
+            Assert.Equal(statusCode, exception.StatusCode);
+            Assert.Equal(responseBody, exception.ResponseBody);
+            Assert.Equal(correlationId, exception.CorrelationId);
+            Assert.Same(innerException, exception.InnerException);
+        }
+
+        [Fact]
+        public void Constructor_WithNullOptionalParams_InitializesCorrectly()
+        {
+            // Arrange
+            const string message = "Test error message";
+            const HttpStatusCode statusCode = HttpStatusCode.Unauthorized;
+
+            // Act
+            var exception = new AmadeusRequestException(
+                message,
+                statusCode,
+                null, // responseBody
+                null, // correlationId
+                null); // innerException
+
+            // Assert
+            Assert.Equal(message, exception.Message);
+            Assert.Equal(statusCode, exception.StatusCode);
+            Assert.Null(exception.ResponseBody);
+            Assert.Null(exception.CorrelationId);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void AmadeusRequestException_InheritsFromAmadeusException()
+        {
+            // Arrange & Act
+            var exception = new AmadeusRequestException(
+                "Test message",
+                HttpStatusCode.InternalServerError,
+                null,
+                null);
+
+            // Assert
+            Assert.IsType<AmadeusRequestException>(exception);
+            Assert.IsAssignableFrom<AmadeusException>(exception);
+        }
+
+        [Fact]
+        public void FromResponse_CreatesExceptionWithCorrectProperties()
+        {
+            // Arrange
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                ReasonPhrase = "Resource Not Found"
+            };
+            const string responseBody = "The requested resource was not found";
+            const string correlationId = "request-123-correlation";
+
+            // Act
+            var exception = AmadeusRequestException.FromResponse(responseMessage, responseBody, correlationId);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
+            Assert.Equal(responseBody, exception.ResponseBody);
+            Assert.Equal(correlationId, exception.CorrelationId);
+            Assert.Contains("404", exception.Message);
+            Assert.Contains("Resource Not Found", exception.Message);
+        }
+
+        [Fact]
+        public void FromResponse_WithNullOptionalParams_CreatesExceptionCorrectly()
+        {
+            // Arrange
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.BadGateway)
+            {
+                ReasonPhrase = "Bad Gateway"
+            };
+
+            // Act
+            var exception = AmadeusRequestException.FromResponse(responseMessage, null, null);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+            Assert.Null(exception.ResponseBody);
+            Assert.Null(exception.CorrelationId);
+            Assert.Contains("502", exception.Message);
+            Assert.Contains("Bad Gateway", exception.Message);
+        }
+
+        [Fact]
+        public void FromResponse_MessageContainsStatusCodeAndReason()
+        {
+            // Arrange
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                ReasonPhrase = "Service Unavailable"
+            };
+
+            // Act
+            var exception = AmadeusRequestException.FromResponse(responseMessage, "Error body", "correlation-xyz");
+
+            // Assert
+            Assert.Contains("503", exception.Message);
+            Assert.Contains("Service Unavailable", exception.Message);
+            Assert.Matches("Request failed with status 503 \\(Service Unavailable\\)\\.", exception.Message);
+        }
+        
+        [Fact]
+        public void ProductAuthenticationException_InitializesProperties()
+        {
+            // Arrange
+            const string message = "Authentication failed";
+            var innerException = new InvalidOperationException("Inner exception");
+
+            // Act
+            var exception = new ProductAuthenticationException(message, innerException);
+
+            // Assert
+            Assert.Equal(message, exception.Message);
+            Assert.Same(innerException, exception.InnerException);
+        }
+
+        [Fact]
+        public void ProductAuthenticationException_InheritsFromAmadeusException()
+        {
+            // Arrange & Act
+            var exception = new ProductAuthenticationException("Authentication failed");
+
+            // Assert
+            Assert.IsType<ProductAuthenticationException>(exception);
+            Assert.IsAssignableFrom<AmadeusException>(exception);
+        }
+    }
+}

--- a/src/AbeckDev.Amadeus.Test/PipelineContextTests.cs
+++ b/src/AbeckDev.Amadeus.Test/PipelineContextTests.cs
@@ -1,0 +1,102 @@
+using System;
+using AbeckDev.Amadeus.Pipeline;
+
+namespace AbeckDev.Amadeus.Test;
+
+public class PipelineContextTests
+{
+    [Fact]
+    public void Constructor_WithoutRequestId_GeneratesNewId()
+    {
+        // Arrange & Act
+        var context = new PipelineContext();
+
+        // Assert
+        Assert.NotNull(context.RequestId);
+        Assert.NotEmpty(context.RequestId);
+        // Should be a GUID without dashes (32 chars)
+        Assert.Equal(32, context.RequestId.Length);
+    }
+
+    [Fact]
+    public void Constructor_WithRequestId_UsesProvidedId()
+    {
+        // Arrange
+        var requestId = "test-request-id";
+
+        // Act
+        var context = new PipelineContext(requestId);
+
+        // Assert
+        Assert.Equal(requestId, context.RequestId);
+    }
+
+    [Fact]
+    public void Attempt_DefaultValue_IsZero()
+    {
+        // Arrange & Act
+        var context = new PipelineContext();
+
+        // Assert
+        Assert.Equal(0, context.Attempt);
+    }
+
+    [Fact]
+    public void Attempt_SetValue_ReturnsSetValue()
+    {
+        // Arrange
+        var context = new PipelineContext();
+        
+        // Act
+        context.Attempt = 3;
+
+        // Assert
+        Assert.Equal(3, context.Attempt);
+    }
+
+    [Fact]
+    public void Items_DefaultValue_IsEmptyDictionary()
+    {
+        // Arrange & Act
+        var context = new PipelineContext();
+
+        // Assert
+        Assert.NotNull(context.Items);
+        Assert.Empty(context.Items);
+    }
+
+    [Fact]
+    public void Items_AddItem_ContainsAddedItem()
+    {
+        // Arrange
+        var context = new PipelineContext();
+        var key = "testKey";
+        var value = "testValue";
+
+        // Act
+        context.Items.Add(key, value);
+
+        // Assert
+        Assert.True(context.Items.ContainsKey(key));
+        Assert.Equal(value, context.Items[key]);
+    }
+
+    [Fact]
+    public void Items_StoreDifferentTypes_RetrievesCorrectTypes()
+    {
+        // Arrange
+        var context = new PipelineContext();
+        
+        // Act
+        context.Items.Add("string", "value");
+        context.Items.Add("int", 42);
+        context.Items.Add("bool", true);
+        context.Items.Add("null", null);
+
+        // Assert
+        Assert.Equal("value", context.Items["string"]);
+        Assert.Equal(42, context.Items["int"]);
+        Assert.Equal(true, context.Items["bool"]);
+        Assert.Null(context.Items["null"]);
+    }
+}

--- a/src/AbeckDev.Amadeus/Configuration/AmadeusClientOptions.cs
+++ b/src/AbeckDev.Amadeus/Configuration/AmadeusClientOptions.cs
@@ -69,8 +69,8 @@ public sealed class AmadeusClientOptions
     /// <summary>
     /// Gets the list of additional HTTP pipeline policies.
     /// </summary>
-    /// <value>An internal list of custom policies added via <see cref="AddPolicy"/>.</value>
-    internal List<IHttpPipelinePolicy> AdditionalPolicies { get; } = new();
+    /// <value>An list of custom policies added via <see cref="AddPolicy"/>.</value>
+    public List<IHttpPipelinePolicy> AdditionalPolicies { get; } = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AmadeusClientOptions"/> class.


### PR DESCRIPTION
Add unit tests for AmadeusClient and related classes; include Moq package for mocking

closes #3 
# Copilot Description
This pull request adds comprehensive unit tests for the `AmadeusClientOptions`, `AmadeusClient`, pipeline context, and exception classes, and makes the `AdditionalPolicies` property of `AmadeusClientOptions` public. These changes improve test coverage and make it easier to configure and verify client options in tests or other code.

**Unit test additions:**

* Added `ClientOptionTests` to verify construction, default values, custom property assignment, and policy management in `AmadeusClientOptions`, as well as tests for `RetryOptions` defaults and custom values.
* Added `AmadeusClientTests` to cover construction, disposal, and logger injection scenarios for `AmadeusClient`.
* Added `PipelineContextTests` to check construction, attempt tracking, and flexible item storage in `PipelineContext`.
* Added `ExceptionTests` for `AmadeusRequestException` and `ProductAuthenticationException`, verifying constructors, inheritance, and static factory methods.

**Package and API changes:**

* Added `Moq` as a test dependency for mocking in unit tests.
* Changed the `AdditionalPolicies` property in `AmadeusClientOptions` from internal to public, allowing external code and tests to access the list of custom policies.